### PR TITLE
upgraded to reqwest 0.9 and thus native-tls to 0.2 and openssl to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alphavantage"
-version = "0.5.0"
+version = "0.5.1"
 description = "Alpha Vantage API client"
 authors = ["António Marques <me@antoniomarques.eu>"]
 license = "MIT/Apache-2.0"
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.82", features = ["derive"] }
 serde_json = "1.0.33"
-reqwest = "0.8.6"
+reqwest = "0.9.11"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -129,7 +129,7 @@ impl Client {
                 error: failure::Error::from(error).compat(),
             })?;
         let status = response.status();
-        if status != reqwest::StatusCode::Ok {
+        if status != reqwest::StatusCode::OK {
             return Err(Error::ServerError {
                 code: status.as_u16(),
             });


### PR DESCRIPTION
This mitigates the compilation error "Unable to detect OpenSSL version"
as outlined in https://github.com/sfackler/rust-openssl/issues/987